### PR TITLE
Update signal_reader.sv

### DIFF
--- a/src/hdl/control_register.sv
+++ b/src/hdl/control_register.sv
@@ -1,97 +1,23 @@
 `timescale 1ns / 1ps
 
-`define REG_UA (7'h1C)
-`define REG_UB (7'h1D)
-
 /// This module stores and manages a control register.
 ///
 /// # Ports
 ///
-///    [clk] system clock.
-///    [reset] synchronous active high reset signal, used to reset the input and outputs of the system.
-///    [ready] used to signal when the bus samples_output is ready to be output.
-///    [analog] four signals representing the four analog inputs.
-///    [samples_output] Values of both analog inputs, being output.
+/// *   [clk] is the system clock.
+/// *   [reset] is the synchronous active high reset signal.
+/// *   [write] is a signal which on the rising edge causes [write_register] to
+///     be latched and written to the control register.
+/// *   [write_register] is the value to be written to the control regiater when
+///     the [write] signal rises.
+/// *   [control] is the current value of the control register.
 module control_register(
-
     input logic clk,
     input logic reset,
-    input analog0_p, analog0_n, analog1_p, analog1_n,
-    output logic ready,
-    output logic [1:0][11:0] samples_output
-);
-    logic [6:0] daddr;
-    logic den;
-    logic [15:0] di;
-    logic dwe;
-    
-    logic busy;
-    logic [4:0] channel;
-    logic [15:0] do_out;
-    logic drdy;
-    logic eoc;
-    logic eos;
-    
-// Instantiation of the ADc
-xadc_wiz_0 xadc_wiz (
-  .di_in(di),              // input wire [15 : 0] di_in
-  .daddr_in(daddr),        // input wire [6 : 0] daddr_in
-  .den_in(den),            // input wire den_in
-  .dwe_in(dwe),            // input wire dwe_in
-  .drdy_out(drdy),        // output wire drdy_out
-  .do_out(do_out),            // output wire [15 : 0] do_out
-  .dclk_in(clk),          // input wire dclk_in
-  .reset_in(reset),        // input wire reset_in
-  .vp_in(1'b0),              // input wire vp_in
-  .vn_in(1'b0),              // input wire vn_in
-  .vauxp4(analog0_p),            // input wire vauxp4
-  .vauxn4(analog0_n),            // input wire vauxn4
-  .vauxp5(analog1_p),            // input wire vauxp5
-  .vauxn5(analog1_n),            // input wire vauxn5
-  .channel_out(channel),  // output wire [4 : 0] channel_out
-  .eoc_out(eoc),          // output wire eoc_out
-  .alarm_out(/* Unused */),      // output wire alarm_out
-  .eos_out(eos),          // output wire eos_out
-  .busy_out(busy)        // output wire busy_out
-);
+    input logic write,
+    input logic [7:0] write_register,
+    output logic control[7:0]);
 
-assign daddr [6:5] = '0;
-assign daddr [4:0] = channel [4:0];
-assign den = eoc;
-assign di = '0;
-assign dwe = drdy;
-
-logic [11:0] ua_code;
-logic [11:0] ub_code;
-
-logic [4:0] prev_channel;
-
-always_ff @ (posedge clk) begin
-    if(reset) begin
-        ua_code <= '0;
-        ub_code <= '0;
-    end 
-    else if (eoc) begin
-        prev_channel <= channel;
-        case (prev_channel)
-            `REG_UA: ua_code <= do_out[15:4];
-            `REG_UB: ub_code <= do_out[15:4];
-        endcase
-    end
-end
-
-//Writes stored ouput when eos is high  in order for the values to be updated at the same time.
-always_ff @ (posedge clk) begin
-    if (reset) begin
-        ready <= 0;
-        samples_output <= '0;  
-    end else if (eos) begin
-        ready <=  1;
-        samples_output [0][11:0] <= ua_code;
-        samples_output [1][11:0] <= ub_code;
-    end else begin
-    ready <= 0;
-    end
-end
+    // TODO
 
 endmodule

--- a/src/hdl/control_register.sv
+++ b/src/hdl/control_register.sv
@@ -9,16 +9,16 @@
 ///
 ///    [clk] system clock.
 ///    [reset] synchronous active high reset signal, used to reset the input and outputs of the system.
-///    [ready] used to signal when the bus ITwoPhase is ready to be output.
+///    [ready] used to signal when the bus samples_output is ready to be output.
 ///    [analog] four signals representing the four analog inputs.
-///    [ITwoPhase] Values of both analog inputs, being output.
+///    [samples_output] Values of both analog inputs, being output.
 module control_register(
 
     input logic clk,
     input logic reset,
     input analog0_p, analog0_n, analog1_p, analog1_n,
     output logic ready,
-    output logic [1:0][11:0]ITwoPhase
+    output logic [1:0][11:0] samples_output
 );
     logic [6:0] daddr;
     logic den;
@@ -70,7 +70,6 @@ always_ff @ (posedge clk) begin
     if(reset) begin
         ua_code <= '0;
         ub_code <= '0;
-        prev_channel <= '0;
     end 
     else if (eoc) begin
         prev_channel <= channel;
@@ -85,11 +84,11 @@ end
 always_ff @ (posedge clk) begin
     if (reset) begin
         ready <= 0;
-        ITwoPhase <= '0;  
+        samples_output <= '0;  
     end else if (eos) begin
         ready <=  1;
-        ITwoPhase [0][11:0] <= ua_code;
-        ITwoPhase [1][11:0] <= ub_code;
+        samples_output [0][11:0] <= ua_code;
+        samples_output [1][11:0] <= ub_code;
     end else begin
     ready <= 0;
     end

--- a/src/hdl/control_register.sv
+++ b/src/hdl/control_register.sv
@@ -1,23 +1,106 @@
 `timescale 1ns / 1ps
+`include "fixed_point.svh"
+`define REG_UA (7'h1C)
+`define REG_UB (7'h1D)
 
 /// This module stores and manages a control register.
 ///
 /// # Ports
 ///
-/// *   [clk] is the system clock.
-/// *   [reset] is the synchronous active high reset signal.
-/// *   [write] is a signal which on the rising edge causes [write_register] to
-///     be latched and written to the control register.
-/// *   [write_register] is the value to be written to the control regiater when
-///     the [write] signal rises.
-/// *   [control] is the current value of the control register.
+///    [std] standard module interface.
+///    [ready] asserted for one clk cycle when conversion sequence is completed
+///    [tp] two phase signals being sampled
+///    [vaux] auxiliary analog inputs.
 module control_register(
-    input logic clk,
-    input logic reset,
-    input logic write,
-    input logic [7:0] write_register,
-    output logic control[7:0]);
 
-    // TODO
+    IStd.in std,
+    IVaux.in vaux,
+    output logic ready,
+    ITwoPhase.out tp
+);
+    logic [6:0] daddr;
+    logic den;
+    logic [15:0] di;
+    logic dwe;
+    
+    logic busy;
+    logic [4:0] channel;
+    logic [15:0] do_out;
+    logic drdy;
+    logic eoc;
+    logic eos;
+    
+// Instantiation of the ADc
+xadc_wiz_0 xadc_wiz (
+  .di_in(di),              // input wire [15 : 0] di_in
+  .daddr_in(daddr),        // input wire [6 : 0] daddr_in
+  .den_in(den),            // input wire den_in
+  .dwe_in(dwe),            // input wire dwe_in
+  .drdy_out(drdy),        // output wire drdy_out
+  .do_out(do_out),            // output wire [15 : 0] do_out
+  .dclk_in(std.clk),          // input wire dclk_in
+  .reset_in(std.reset),        // input wire reset_in
+  .vp_in(1'b0),              // input wire vp_in
+  .vn_in(1'b0),              // input wire vn_in
+  .vauxp4(vaux.p4),            // input wire vauxp4
+  .vauxn4(vaux.n4),            // input wire vauxn4
+  .vauxp5(vaux.p5),            // input wire vauxp5
+  .vauxn5(vaux.n5),            // input wire vauxn5
+  .channel_out(channel),  // output wire [4 : 0] channel_out
+  .eoc_out(eoc),          // output wire eoc_out
+  .alarm_out(/* Unused */),      // output wire alarm_out
+  .eos_out(eos),          // output wire eos_out
+  .busy_out(busy)        // output wire busy_out
+);
+
+assign daddr [6:5] = '0;
+assign daddr [4:0] = channel [4:0];
+assign den =eoc;
+assign di = '0;
+assign dwe = drdy;
+
+logic [11:0] ua_code;
+logic [11:0] ub_code;
+
+logic [4:0] prev_channel;
+
+always_ff @ (posedge std.clk) begin
+    if(std.reset) begin
+        ua_code <= '0;
+        ub_code <= '0;
+        prev_channel <= '0;
+    end 
+    else if (eoc) begin
+        prev_channel <= channel;
+        case (prev_channel)
+            `REG_UA: ua_code <= do_out[15:4];
+            `REG_UB: ub_code <= do_out[15:4];
+        endcase
+    end
+end
+
+logic ready_one_cycle;
+
+//Writes stored ouput when eos is high  in order for the values to be updated at the same time.
+always_ff @ (posedge atd.clk) begin
+    if (std.reset) begin
+        ready_one_cycle <= 0;
+        tp.ua <= `FIX2420_invalid;
+        tp.ub <= `FIX2420_invalid;
+    end else if (eos) begin
+        ready_one_cycle <=  1;
+        tp.ua.num [23:20] <= {4{ua_code[11]}};
+        tp.ua.num [19:8] <= ua_code;
+        tp.ua.valid <= 1;
+        tp.ub.num [23:20] <= {4{ua_code[11]}};
+        tp.ub.num [19:8] <= ub_code;
+        tp.ub.valid <= 1;
+    end else begin
+    ready_one_cycle <= 0;
+    end
+end
+
+// hold ready signal high for 2 std.clk in order to be read by a clock at half the speed
+hold #(.CYCLES(2)) hold_ready(.std(std), .a(ready_one_cycle), .high(ready));
 
 endmodule

--- a/src/hdl/signal_reader.sv
+++ b/src/hdl/signal_reader.sv
@@ -1,5 +1,8 @@
 `timescale 1ns / 1ps
 
+`define REG_UA (7'h1C)
+`define REG_UB (7'h1D)
+
 /// This module controls the on-chip ADC and monitors the incoming digital
 /// lines. The module is responsible for sampling the data at a reasonable rate.
 ///
@@ -7,27 +10,94 @@
 ///
 /// *   [clk] is the system clock.
 /// *   [reset] is the synchronous active high reset signal.
-/// *   [digital] is the digital bus to be sampled for the logic analyzer.
 /// *   [analog_p] is a bus of positive sides of the anlog inputs.
 /// *   [analog_n] is a bus of negative sides of the anlog inputs.
 /// *   [analog_out] is a bus of sampled 12-bit ADC values on the analog
 ///     channels. This only valid while [ready] is high.
-/// *   [digital_out] is a bus of sampled values on the digital lines. This only
-///     valid while [ready] is high.
-/// *   [ready] indicates that the analog and digital values have been sampled
-///     and written to [analog_out] and [digital_out]. The [ready] signal is
-///     only held high for one clock cycle, so the [analog_out] and
-///     [digital_out] must be used on the rising edge of [ready].
+/// *   [ready] indicates that the analog values have been sampled
+///     and written to [analog_out]. The [ready] signal is
+///     only held high for one clock cycle, so the must be used on the rising edge of [ready].
+
 module signal_reader(
+
     input logic clk,
     input logic reset,
-    input logic [7:0] digital,
-    input logic [1:0] analog_p,
-    input logic [1:0] analog_n,
-    output logic [1:0][11:0] analog_out,
-    output logic [7:0] digital_out,
-    output logic ready);
+    input analog0_p, analog0_n, analog1_p, analog1_n,
+    output logic ready,
+    output logic [1:0][11:0] analog_out
+);
+    logic [6:0] daddr;
+    logic den;
+    logic [15:0] di;
+    logic dwe;
+    
+    logic busy;
+    logic [4:0] channel;
+    logic [15:0] do_out;
+    logic drdy;
+    logic eoc;
+    logic eos;
+    
+// Instantiation of the ADc
+xadc_wiz_0 xadc_wiz (
+  .di_in(di),              // input wire [15 : 0] di_in
+  .daddr_in(daddr),        // input wire [6 : 0] daddr_in
+  .den_in(den),            // input wire den_in
+  .dwe_in(dwe),            // input wire dwe_in
+  .drdy_out(drdy),        // output wire drdy_out
+  .do_out(do_out),            // output wire [15 : 0] do_out
+  .dclk_in(clk),          // input wire dclk_in
+  .reset_in(reset),        // input wire reset_in
+  .vp_in(1'b0),              // input wire vp_in
+  .vn_in(1'b0),              // input wire vn_in
+  .vauxp4(analog0_p),            // input wire vauxp4
+  .vauxn4(analog0_n),            // input wire vauxn4
+  .vauxp5(analog1_p),            // input wire vauxp5
+  .vauxn5(analog1_n),            // input wire vauxn5
+  .channel_out(channel),  // output wire [4 : 0] channel_out
+  .eoc_out(eoc),          // output wire eoc_out
+  .alarm_out(/* Unused */),      // output wire alarm_out
+  .eos_out(eos),          // output wire eos_out
+  .busy_out(busy)        // output wire busy_out
+);
 
-    // TODO
+assign daddr [6:5] = '0;
+assign daddr [4:0] = channel [4:0];
+assign den = eoc;
+assign di = '0;
+assign dwe = drdy;
+
+logic [11:0] ua_code;
+logic [11:0] ub_code;
+
+logic [4:0] prev_channel;
+
+always_ff @ (posedge clk) begin
+    if(reset) begin
+        ua_code <= '0;
+        ub_code <= '0;
+    end 
+    else if (eoc) begin
+        prev_channel <= channel;
+        case (prev_channel)
+            `REG_UA: ua_code <= do_out[15:4];
+            `REG_UB: ub_code <= do_out[15:4];
+        endcase
+    end
+end
+
+//Writes stored ouput when eos is high  in order for the values to be updated at the same time.
+always_ff @ (posedge clk) begin
+    if (reset) begin
+        ready <= 0;
+        analog_out <= '0;  
+    end else if (eos) begin
+        ready <=  1;
+        analog_out [0][11:0] <= ua_code;
+        analog_out [1][11:0] <= ub_code;
+    end else begin
+    ready <= 0;
+    end
+end
 
 endmodule


### PR DESCRIPTION
update to the control register portion of the oscilloscope.
Currently "IStd", "IVaux", "ITwoPhase", and "fixed_point.svh" are not implemented.